### PR TITLE
Add vcs-browser URL tag to metainfo-fixed.xml

### DIFF
--- a/metainfo-fixed.xml
+++ b/metainfo-fixed.xml
@@ -75,6 +75,7 @@
     </screenshot>
   </screenshots>
   <url type="homepage">https://zbridge.club</url>
+  <url type="vcs-browser">https://github.com/amitter84/zbridge-flatpak-source</url>
   <content_rating type="oars-1.1"/>
   <releases>
     <release version="1.1.5" date="2025-12-25" />

--- a/metainfo-fixed.xml
+++ b/metainfo-fixed.xml
@@ -76,6 +76,14 @@
   </screenshots>
   <url type="homepage">https://zbridge.club</url>
   <url type="vcs-browser">https://github.com/amitter84/zbridge-flatpak-source</url>
+  <supports>
+    <control>touch</control>
+    <control>pointing</control>
+    <control>keyboard</control>
+  </supports>
+  <requires>
+    <display_length compare="ge">360</display_length>
+  </requires>
   <content_rating type="oars-1.1"/>
   <releases>
     <release version="1.1.5" date="2025-12-25" />


### PR DESCRIPTION
 Hi Stella & Charlie,

 Thanks for the review and approval!

 I have added the <url type="vcs-browser">https://github.com/amitter84/zbridge-flatpak-source</url> tag to the AppStream metainfo file and merged it into master.

 Best regards,
 Anik
