### PR TITLE
fix: revert project_license to LicenseRef-proprietary and update desc…

### DIFF
--- a/metainfo-fixed.xml
+++ b/metainfo-fixed.xml
@@ -7,28 +7,28 @@
   </developer>
   <summary>Play contract bridge online</summary>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>GPL-3.0-or-later</project_license>
+  <project_license>LicenseRef-proprietary</project_license>
   <description>
     <p>
-      Contract bridge is a trick-taking card game for four players, divided into two partnerships sitting opposite each other (North-South vs. East-West).
+      Contract bridge game with single and double dummy solver.
     </p>
     <p>
-      zBridge is an online bridge club where you can learn and play bridge. It is a full bridge platform with multiple features.
+      Zbridge is a complete contract bridge platform for players of all skill levels. Learn, practice, and play contract bridge online or hone your skills with our advanced AI bridge bot and deal analysis tools.
+    </p>
+    <p>Key Features of Zbridge:</p>
+    <ul>
+      <li>Advanced Bot (Jethro): Play contract bridge with Jethro, a competitive bot built on 2/1 Game Forcing principles. Utilizing probability-based play algorithms based on known hand information, Jethro acts as a formidable opponent and reliable partner.</li>
+      <li>Interactive Learning &amp; Tutorials: Perfect for beginners and improvers. Learn how to play bridge step-by-step with interactive lessons and guided bidding hints.</li>
+      <li>Bidding &amp; Deal Analysis Room: Analyze custom or random deals with single and double dummy solver analysis. Practice 2/1 bidding, review possible trick counts for any contract, and view detailed bid explanations from the AI.</li>
+      <li>Multiplayer Game Rooms: Join casual, social, or rated duplicate bridge tables. Track your performance with game records and player rating systems.</li>
+      <li>Community &amp; Social Features: Create bidding polls, publish bridge articles, participate in lobby chat, add friends, and send private messages.</li>
+      <li>Ad-Free Experience: Zbridge is completely free to play with no adware.</li>
+    </ul>
+    <p>
+      Whether you want to practice 2/1 bidding against AI, solve complex double dummy hands, or compete in online multiplayer duplicate games, Zbridge provides a complete suite for bridge enthusiasts.
     </p>
     <p>
-      Play with Jethro, a competitive bridge bot for 2/1 game forcing, try our interactive tutorials, join multiplayer games in social and rated rooms, or analyse custom/random deals in the analysis room to practice different bidding and playing scenarios with hints from the AI. Compose bidding polls or bridge articles. The app features a duplicate scoring system, game records and a rating system for players. It is completely free and without any adware. Our mission is to provide a premium experience to bridge enthusiasts on all platforms.
-    </p>
-    <p>
-      In the analysis and bot rooms, Jethro offers a detailed explanation for each bid made with a suggestion for your next bid. This is a great tool for learners to improve their bidding. The nuanced human like bidding of Jethro means that it can provide hours of fun for intermediate and expert players as well. The double dummy solver used for the playing phase is wrapped by an algorithm to chose the most appropriate card from among the DDS choices to avoid complete robotic play where possible without compromising on achieving the best outcome. This combination creates a great partner and a formidable opponent to improve your game. The analysis room also features a complete double dummy analysis showing the possible tricks for any contract. The analysis room is the ideal place to practice 2/1 bidding with the bot on random or custom hands.
-    </p>
-    <p>
-      For the best experience, we advise newcomers to first go through the 'How to play bridge' tutorial, then the interactive tutorial and then learn continuously by playing with Jethro before stepping into multiplayer game rooms.
-    </p>
-    <p>
-      Members can also create bidding polls and blog posts to engage with the community. The lobby and rooms also have a community chat. Members can also send friend requests and private messages.
-    </p>
-    <p>
-      Join zbridge today!
+      Download Zbridge today to start playing and practicing!
     </p>
   </description>
   <launchable type="desktop-id">club.zbridge.zbridge.desktop</launchable>


### PR DESCRIPTION
Thanks for catching that! The web application service is proprietary though the wrapper is open source. So I have reverted <project_license> back to LicenseRef-proprietary in the metainfo file and updated the app description. Please let me know if any further changes are needed.