### PR TITLE
Update compliant icon and screenshots

### DIFF
--- a/club.zbridge.zbridge.metainfo.xml
+++ b/club.zbridge.zbridge.metainfo.xml
@@ -9,8 +9,8 @@
   </developer>
   <summary>Play contract bridge online</summary>
   <branding>
-    <color type="primary" scheme_preference="light">#c19571</color>
-    <color type="primary" scheme_preference="dark">#7c2d12</color>
+    <color type="primary" scheme_preference="light">#46c073</color>
+    <color type="primary" scheme_preference="dark">#29563c</color>
   </branding>
   <description>
     <p>

--- a/club.zbridge.zbridge.svg
+++ b/club.zbridge.zbridge.svg
@@ -83,7 +83,7 @@
     </clipPath>
   </defs>
 
-  <g transform="translate(64, 64) scale(1.02) translate(-64, -64)">
+  <g transform="translate(64, 64) scale(1.04) translate(-64, -64)">
     <!-- 3D BASE TILE: Compact tile cleanly padded inside 128x128 grid (NO OUTSIDE SHADOW) -->
     <g>
       <rect x="14" y="17" width="100" height="97" rx="16" ry="16" fill="url(#tileBevel)"/>

--- a/club.zbridge.zbridge.svg
+++ b/club.zbridge.zbridge.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="128" height="128" viewBox="0 0 128 128" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="102" height="102" viewBox="0 0 128 128" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <defs>
     <!-- 3D Felt Green Tile Gradients & Shadows -->
     <linearGradient id="tileSurface" x1="0%" y1="0%" x2="0%" y2="100%">
@@ -10,7 +10,7 @@
 
     <linearGradient id="tileBevel" x1="0%" y1="0%" x2="0%" y2="100%">
       <stop offset="0%" stop-color="#1b5c2f"/>
-      <stop offset="100%" stop-color="#134725"/>
+      <stop offset="100%" stop-color="#1d572d"/>
     </linearGradient>
 
     <linearGradient id="topHighlightRim" x1="0%" y1="0%" x2="0%" y2="100%">
@@ -56,6 +56,7 @@
       <stop offset="40%" stop-color="#ef4444"/>
       <stop offset="100%" stop-color="#991b1b"/>
     </linearGradient>
+
 
     <filter id="cardShadow3D" x="-30%" y="-30%" width="160%" height="160%">
       <feDropShadow dx="2" dy="6" stdDeviation="4" flood-color="#031207" flood-opacity="0.55"/>

--- a/club.zbridge.zbridge.svg
+++ b/club.zbridge.zbridge.svg
@@ -79,16 +79,16 @@
 
     <!-- Clip path to keep all internal elements strictly inside the base tile squircle -->
     <clipPath id="tileClip">
-      <rect x="14" y="14" width="100" height="100" rx="25" ry="25"/>
+      <rect x="14" y="14" width="100" height="100" rx="16" ry="16"/>
     </clipPath>
   </defs>
 
   <g transform="translate(64, 64) scale(1.02) translate(-64, -64)">
     <!-- 3D BASE TILE: Compact tile cleanly padded inside 128x128 grid (NO OUTSIDE SHADOW) -->
     <g>
-      <rect x="14" y="17" width="100" height="97" rx="25" ry="25" fill="url(#tileBevel)"/>
-      <rect x="14" y="14" width="100" height="97" rx="25" ry="25" fill="url(#tileSurface)"/>
-      <rect x="14" y="14" width="100" height="97" rx="25" ry="25" fill="none" stroke="url(#topHighlightRim)" stroke-width="1.5"/>
+      <rect x="14" y="17" width="100" height="97" rx="16" ry="16" fill="url(#tileBevel)"/>
+      <rect x="14" y="14" width="100" height="97" rx="16" ry="16" fill="url(#tileSurface)"/>
+      <rect x="14" y="14" width="100" height="97" rx="16" ry="16" fill="none" stroke="url(#topHighlightRim)" stroke-width="1.5"/>
     </g>
 
     <!-- INNER CONTENT CLIPPED STRICTLY TO BASE TILE -->

--- a/club.zbridge.zbridge.svg
+++ b/club.zbridge.zbridge.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="102" height="102" viewBox="0 0 128 128" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="128" height="128" viewBox="0 0 128 128" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <defs>
     <!-- 3D Felt Green Tile Gradients & Shadows -->
     <linearGradient id="tileSurface" x1="0%" y1="0%" x2="0%" y2="100%">
@@ -57,7 +57,6 @@
       <stop offset="100%" stop-color="#991b1b"/>
     </linearGradient>
 
-
     <filter id="cardShadow3D" x="-30%" y="-30%" width="160%" height="160%">
       <feDropShadow dx="2" dy="6" stdDeviation="4" flood-color="#031207" flood-opacity="0.55"/>
     </filter>
@@ -84,36 +83,38 @@
     </clipPath>
   </defs>
 
-  <!-- 3D BASE TILE: Compact 100x100 tile cleanly padded inside 128x128 grid (NO OUTSIDE SHADOW) -->
-  <g>
-    <rect x="14" y="17" width="100" height="97" rx="25" ry="25" fill="url(#tileBevel)"/>
-    <rect x="14" y="14" width="100" height="97" rx="25" ry="25" fill="url(#tileSurface)"/>
-    <rect x="14" y="14" width="100" height="97" rx="25" ry="25" fill="none" stroke="url(#topHighlightRim)" stroke-width="1.5"/>
-  </g>
-
-  <!-- INNER CONTENT CLIPPED STRICTLY TO BASE TILE -->
-  <g clip-path="url(#tileClip)">
-    <!-- 3D GOLDEN BRIDGE ARCH STRUCTURE -->
-    <g filter="url(#archShadow3D)">
-      <path d="M 28 88 C 44 52, 84 52, 100 88" fill="none" stroke="#04150a" stroke-width="8" opacity="0.4"/>
-      <path d="M 28 88 C 44 52, 84 52, 100 88" fill="none" stroke="url(#gold3D)" stroke-width="6" stroke-linecap="round"/>
-      <path d="M 28 87.5 C 44 52.5, 84 52.5, 100 87.5" fill="none" stroke="url(#goldSpecular)" stroke-width="1.5" stroke-linecap="round"/>
-      <path d="M 28 88 L 100 88" stroke="url(#gold3D)" stroke-width="3.5" stroke-linecap="round"/>
+  <g transform="translate(64, 64) scale(1.02) translate(-64, -64)">
+    <!-- 3D BASE TILE: Compact tile cleanly padded inside 128x128 grid (NO OUTSIDE SHADOW) -->
+    <g>
+      <rect x="14" y="17" width="100" height="97" rx="25" ry="25" fill="url(#tileBevel)"/>
+      <rect x="14" y="14" width="100" height="97" rx="25" ry="25" fill="url(#tileSurface)"/>
+      <rect x="14" y="14" width="100" height="97" rx="25" ry="25" fill="none" stroke="url(#topHighlightRim)" stroke-width="1.5"/>
     </g>
 
-    <!-- 3D PLAYING CARDS WITH PHYSICAL THICKNESS -->
-    <!-- Card 1: Ace of Spades (Left, tilted -12°) -->
-    <g transform="translate(50, 56) rotate(-12)" filter="url(#cardShadow3D)">
-      <rect x="-18" y="-26" width="37" height="53" rx="4.5" fill="url(#cardThickness)"/>
-      <rect x="-19.5" y="-27.5" width="38" height="54" rx="4" fill="url(#cardFront)" stroke="#cbd5e1" stroke-width="0.75"/>
-      <use href="#spade3D" transform="scale(0.8)"/>
-    </g>
+    <!-- INNER CONTENT CLIPPED STRICTLY TO BASE TILE -->
+    <g clip-path="url(#tileClip)">
+      <!-- 3D GOLDEN BRIDGE ARCH STRUCTURE -->
+      <g filter="url(#archShadow3D)">
+        <path d="M 28 88 C 44 52, 84 52, 100 88" fill="none" stroke="#04150a" stroke-width="8" opacity="0.4"/>
+        <path d="M 28 88 C 44 52, 84 52, 100 88" fill="none" stroke="url(#gold3D)" stroke-width="6" stroke-linecap="round"/>
+        <path d="M 28 87.5 C 44 52.5, 84 52.5, 100 87.5" fill="none" stroke="url(#goldSpecular)" stroke-width="1.5" stroke-linecap="round"/>
+        <path d="M 28 88 L 100 88" stroke="url(#gold3D)" stroke-width="3.5" stroke-linecap="round"/>
+      </g>
 
-    <!-- Card 2: Ace of Hearts (Right, tilted +14°, overlapping) -->
-    <g transform="translate(77, 58) rotate(14)" filter="url(#cardShadow3D)">
-      <rect x="-18" y="-26" width="37" height="53" rx="4.5" fill="url(#cardThickness)"/>
-      <rect x="-19.5" y="-27.5" width="38" height="54" rx="4" fill="url(#cardFront)" stroke="#cbd5e1" stroke-width="0.75"/>
-      <use href="#heart3D" transform="scale(0.8)"/>
+      <!-- 3D PLAYING CARDS WITH PHYSICAL THICKNESS -->
+      <!-- Card 1: Ace of Spades (Left, tilted -12°) -->
+      <g transform="translate(50, 56) rotate(-12)" filter="url(#cardShadow3D)">
+        <rect x="-18" y="-26" width="37" height="53" rx="4.5" fill="url(#cardThickness)"/>
+        <rect x="-19.5" y="-27.5" width="38" height="54" rx="4" fill="url(#cardFront)" stroke="#cbd5e1" stroke-width="0.75"/>
+        <use href="#spade3D" transform="scale(0.8)"/>
+      </g>
+
+      <!-- Card 2: Ace of Hearts (Right, tilted +14°, overlapping) -->
+      <g transform="translate(77, 58) rotate(14)" filter="url(#cardShadow3D)">
+        <rect x="-18" y="-26" width="37" height="53" rx="4.5" fill="url(#cardThickness)"/>
+        <rect x="-19.5" y="-27.5" width="38" height="54" rx="4" fill="url(#cardFront)" stroke="#cbd5e1" stroke-width="0.75"/>
+        <use href="#heart3D" transform="scale(0.8)"/>
+      </g>
     </g>
   </g>
 </svg>

--- a/club.zbridge.zbridge.yaml
+++ b/club.zbridge.zbridge.yaml
@@ -45,7 +45,7 @@ modules:
   - type: git
     url: https://github.com/amitter84/zbridge-flatpak-source.git
     tag: v1.1.8
-    commit: bee8cff477ac0e0eb3592f6208522bd27bfc7a9d
+    commit: 145efb7f7f8df708ea6edab46c7d597be93514be
   - dest: flatpak-node/cache/electron
     only-arches:
     - x86_64
@@ -80,7 +80,7 @@ modules:
   - type: git
     url: https://github.com/amitter84/zbridge-flatpak-source.git
     tag: v1.1.8
-    commit: bee8cff477ac0e0eb3592f6208522bd27bfc7a9d
+    commit: 145efb7f7f8df708ea6edab46c7d597be93514be
   - type: file
     path: club.zbridge.zbridge.metainfo.xml
   - type: file

--- a/club.zbridge.zbridge.yaml
+++ b/club.zbridge.zbridge.yaml
@@ -45,7 +45,7 @@ modules:
   - type: git
     url: https://github.com/amitter84/zbridge-flatpak-source.git
     tag: v1.1.8
-    commit: 3d1f0a119e6afefca806e539a7a9dd6f6db13bb6
+    commit: bee8cff477ac0e0eb3592f6208522bd27bfc7a9d
   - dest: flatpak-node/cache/electron
     only-arches:
     - x86_64
@@ -80,7 +80,7 @@ modules:
   - type: git
     url: https://github.com/amitter84/zbridge-flatpak-source.git
     tag: v1.1.8
-    commit: 3d1f0a119e6afefca806e539a7a9dd6f6db13bb6
+    commit: bee8cff477ac0e0eb3592f6208522bd27bfc7a9d
   - type: file
     path: club.zbridge.zbridge.metainfo.xml
   - type: file

--- a/club.zbridge.zbridge.yaml
+++ b/club.zbridge.zbridge.yaml
@@ -45,7 +45,7 @@ modules:
   - type: git
     url: https://github.com/amitter84/zbridge-flatpak-source.git
     tag: v1.1.8
-    commit: 145efb7f7f8df708ea6edab46c7d597be93514be
+    commit: 147eb92495400624d55c68e2f366ac8e9a638984
   - dest: flatpak-node/cache/electron
     only-arches:
     - x86_64
@@ -80,7 +80,7 @@ modules:
   - type: git
     url: https://github.com/amitter84/zbridge-flatpak-source.git
     tag: v1.1.8
-    commit: 145efb7f7f8df708ea6edab46c7d597be93514be
+    commit: 147eb92495400624d55c68e2f366ac8e9a638984
   - type: file
     path: club.zbridge.zbridge.metainfo.xml
   - type: file

--- a/club.zbridge.zbridge.yaml
+++ b/club.zbridge.zbridge.yaml
@@ -45,7 +45,7 @@ modules:
   - type: git
     url: https://github.com/amitter84/zbridge-flatpak-source.git
     tag: v1.1.8
-    commit: 147eb92495400624d55c68e2f366ac8e9a638984
+    commit: 7d98c5fc6884a26c412a3bce1fc19f649a9fe38b
   - dest: flatpak-node/cache/electron
     only-arches:
     - x86_64
@@ -80,7 +80,7 @@ modules:
   - type: git
     url: https://github.com/amitter84/zbridge-flatpak-source.git
     tag: v1.1.8
-    commit: 147eb92495400624d55c68e2f366ac8e9a638984
+    commit: 7d98c5fc6884a26c412a3bce1fc19f649a9fe38b
   - type: file
     path: club.zbridge.zbridge.metainfo.xml
   - type: file


### PR DESCRIPTION
Icon now has lighter bottom edge for better contrast on dark backgrounds. Icon is little bigger in size to fill inner grid square fully. Screenshots now have native shadows and window controls. Note that bottom corners are not rounded natively on my app and so only top corners are rounded.