### PR TITLE
Update screenshots and metainfo for Flathub

### DIFF
--- a/club.zbridge.zbridge.metainfo.xml
+++ b/club.zbridge.zbridge.metainfo.xml
@@ -31,21 +31,21 @@
   </description>
   <launchable type="desktop-id">club.zbridge.zbridge.desktop</launchable>
   <screenshots>
-    <screenshot type="default">
-      <caption>Learn to play</caption>
+    <screenshot>
+      <caption>Learn to play bridge</caption>
       <image>https://raw.githubusercontent.com/amitter84/zbridge-flatpak-source/main/screenshots/learn_to_play.png</image>
     </screenshot>
-    <screenshot>
-      <caption>Play with Bot</caption>
+    <screenshot type="default">
+      <caption>Play with the bot, Jethro</caption>
       <image>https://raw.githubusercontent.com/amitter84/zbridge-flatpak-source/main/screenshots/play_with_bot.png</image>
     </screenshot>
     <screenshot>
-      <caption>Bridge Solver - dark theme</caption>
+      <caption>Analysis room with single and double dummy solvers (dark mode)</caption>
       <image>https://raw.githubusercontent.com/amitter84/zbridge-flatpak-source/main/screenshots/bridge_solver.png</image>
     </screenshot>
     <screenshot>
-      <caption>Monthly Events</caption>
-      <image>https://raw.githubusercontent.com/amitter84/zbridge-flatpak-source/main/screenshots/monthly_events.png</image>
+      <caption>Replay games with analysis</caption>
+      <image>https://raw.githubusercontent.com/amitter84/zbridge-flatpak-source/main/screenshots/replay_games.png</image>
     </screenshot>
   </screenshots>
   <url type="homepage">https://zbridge.club</url>

--- a/club.zbridge.zbridge.yaml
+++ b/club.zbridge.zbridge.yaml
@@ -44,8 +44,8 @@ modules:
   sources:
   - type: git
     url: https://github.com/amitter84/zbridge-flatpak-source.git
-    tag: v1.1.8
-    commit: 9aa233ecca58436772f03880630e5372c4351d98
+    tag: v1.1.8-1
+    commit: 37e19807b289d9544f1e668d1158336fcc0f07f4
   - dest: flatpak-node/cache/electron
     only-arches:
     - x86_64
@@ -79,8 +79,8 @@ modules:
   sources:
   - type: git
     url: https://github.com/amitter84/zbridge-flatpak-source.git
-    tag: v1.1.8
-    commit: 9aa233ecca58436772f03880630e5372c4351d98
+    tag: v1.1.8-1
+    commit: 37e19807b289d9544f1e668d1158336fcc0f07f4
   - type: file
     path: club.zbridge.zbridge.metainfo.xml
   - type: file


### PR DESCRIPTION
Trying to have only most relevant app screenshots to address the one red flag for screenshot content - note that all screenshots and captions are up to date with the current app. Can you please help me understand the exact reason if it that one red flag still remains.

Thanks.